### PR TITLE
Fix Windows w/ Python 3.8 and 3.10 builds by setting MPL backend

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,10 @@ test:
     - orix.sampling
     - orix.vector
   commands:
-    - pytest --pyargs orix -k "not test_plot_masked_phase and not test_plot_ipf_color_key"
+    - pip check
+    - export MPLBACKEND=agg  # [unix]
+    - set MPLBACKEND=agg  # [win]
+    - pytest --pyargs orix
 
 about:
   home: https://orix.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b1ed6f740a94ed5bca3cf7661eeedfc4c5f12007477cf61558b7fba1c39a5907
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<37]
   script: '{{ PYTHON }} -m pip install . -vv '
 
@@ -48,7 +48,7 @@ test:
     - orix.sampling
     - orix.vector
   commands:
-    - pytest --pyargs orix
+    - pytest --pyargs orix -k "not test_plot_masked_phase and not test_plot_ipf_color_key"
 
 about:
   home: https://orix.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
 
 test:
   requires:
+    - pip
     - pytest
   imports:
     - orix


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Terribly sorry about this, but I forgot that our `meta.yaml` file instructs `conda-forge` to not upload builds with failing tests. This means that the new build did not make versions available for Windows with Python 3.8 or 3.10 ([see failing tests](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=576957&view=logs&jobId=171a126d-c574-5c8c-1269-ff3b989e923d&j=171a126d-c574-5c8c-1269-ff3b989e923d)) (the old build is still available). ~The short term fix is to ignore these tests.~ The failing tests were related to not finding a Matplotlib backend. The tests pass fine in our upstream test suite because we set the backend to `agg` there, but we did not do it here. This PR fixes that.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [n/a] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
